### PR TITLE
feat: 연관 관계 매핑

### DIFF
--- a/src/main/java/com/codestates/notice_project/Member/controller/MemberController.java
+++ b/src/main/java/com/codestates/notice_project/Member/controller/MemberController.java
@@ -4,6 +4,7 @@ import com.codestates.notice_project.Member.dto.MemberDto;
 import com.codestates.notice_project.Member.entity.Member;
 import com.codestates.notice_project.Member.mapper.MemberMapper;
 import com.codestates.notice_project.Member.service.MemberService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -11,14 +12,15 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
+import java.util.List;
 
 @RestController
 @RequestMapping("/members")
 @Validated
 public class MemberController {
 
-    private MemberService memberService;
-    private MemberMapper mapper;
+    private final MemberService memberService;
+    private final MemberMapper mapper;
 
     public MemberController(MemberService memberService, MemberMapper mapper) {
         this.memberService = memberService;
@@ -63,7 +65,12 @@ public class MemberController {
     @GetMapping
     public ResponseEntity getMembers(@Positive @RequestParam int page,
                                      @Positive @RequestParam int size) {
-        return null;
+
+        Page<Member> members = memberService.findMembers(page - 1, size);
+        List<Member> memberList = members.getContent();
+        List<MemberDto.Response> responses = mapper.membersToMemberResponse(memberList);
+
+        return new ResponseEntity<>(responses, HttpStatus.OK);
     }
 
     //Member 삭제

--- a/src/main/java/com/codestates/notice_project/Member/dto/MemberDto.java
+++ b/src/main/java/com/codestates/notice_project/Member/dto/MemberDto.java
@@ -1,13 +1,14 @@
 package com.codestates.notice_project.Member.dto;
 
-import lombok.Setter;
+import lombok.*;
 
 import javax.validation.constraints.Email;
 import javax.validation.constraints.NotBlank;
 
 public class MemberDto {
 
-    public class Post {
+    @Getter
+    public static class Post {
 
         @NotBlank(message = "이름을 입력하세요.")
         private String name;
@@ -20,23 +21,19 @@ public class MemberDto {
         private String email;
     }
 
-    @Setter
-    public class Patch {
+    @Getter
+    public static class Patch {
 
+        @Setter
         private long memberId;
-
-        @NotBlank(message = "이름을 입력하세요.")
         private String name;
-
-        @NotBlank
         private String password;
-
-        @NotBlank
-        @Email
         private String email;
     }
 
-    public class Response {
+    @AllArgsConstructor
+    @Getter
+    public static class Response {
 
         private long memberId;
         private String name;

--- a/src/main/java/com/codestates/notice_project/Member/entity/Member.java
+++ b/src/main/java/com/codestates/notice_project/Member/entity/Member.java
@@ -2,13 +2,54 @@ package com.codestates.notice_project.Member.entity;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.w3c.dom.stylesheets.LinkStyle;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
+@Entity
 public class Member {
 
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private long memberId;
+
+    @Column(length = 100, nullable = false)
     private String name;
+
+    @Column(length = 100, nullable = false)
     private String password;
+
+    @Column(length = 100, nullable = false)
     private String email;
+
+    @Enumerated(value = EnumType.STRING)
+    @Column(length = 20, nullable = false)
+    private MemberStatus memberStatus = MemberStatus.MEMBER_ACTIVE;
+
+    @OneToMany(mappedBy = "member", cascade = CascadeType.PERSIST)
+    private List<MemberBoard> memberBoards = new ArrayList<>();
+
+    public void addMemberBoard(MemberBoard memberBoard) {
+        this.memberBoards.add(memberBoard);
+        if (memberBoard.getMember() != this) {
+            memberBoard.addMember(this);
+        }
+    }
+
+    public enum MemberStatus {
+        MEMBER_ACTIVE("활동 중"),
+        MEMBER_SLEEP("휴면 상태"),
+        MEMBER_QUIT("탈퇴 상태");
+
+        @Getter
+        private String status;
+
+        MemberStatus(String status) {
+            this.status = status;
+        }
+    }
 }

--- a/src/main/java/com/codestates/notice_project/Member/entity/MemberBoard.java
+++ b/src/main/java/com/codestates/notice_project/Member/entity/MemberBoard.java
@@ -1,0 +1,37 @@
+package com.codestates.notice_project.Member.entity;
+
+import com.codestates.notice_project.board.entity.Board;
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+public class MemberBoard {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long memberBoardId;
+
+    @ManyToOne
+    @JoinColumn(name = "MEMBER_ID")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "BOARD_ID")
+    private Board board;
+
+    public void addMember(Member member) {
+        this.member = member;
+        if (!this.member.getMemberBoards().contains(this)) {
+            this.member.getMemberBoards().add(this);
+        }
+    }
+
+    public void addBoard(Board board) {
+        this.board = board;
+        if (!this.board.getMemberBoards().contains(this)) {
+            this.board.getMemberBoards().add(this);
+        }
+    }
+}

--- a/src/main/java/com/codestates/notice_project/Member/repository/MemberRepository.java
+++ b/src/main/java/com/codestates/notice_project/Member/repository/MemberRepository.java
@@ -1,7 +1,10 @@
 package com.codestates.notice_project.Member.repository;
 
 import com.codestates.notice_project.Member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
 
 public interface MemberRepository extends JpaRepository<Member, Long> {
-
+    Optional<Member> findByEmail(String email);
 }

--- a/src/main/java/com/codestates/notice_project/Member/service/MemberService.java
+++ b/src/main/java/com/codestates/notice_project/Member/service/MemberService.java
@@ -2,6 +2,9 @@ package com.codestates.notice_project.Member.service;
 
 import com.codestates.notice_project.Member.entity.Member;
 import com.codestates.notice_project.Member.repository.MemberRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -35,6 +38,7 @@ public class MemberService {
         // 수정 사항이 있으면 데이터 변경
         Optional.ofNullable(member.getName()).ifPresent(name -> findMember.setName(name));
         Optional.ofNullable(member.getPassword()).ifPresent(password -> findMember.setPassword(password));
+        Optional.ofNullable(member.getMemberStatus()).ifPresent(memberStatus -> findMember.setMemberStatus(memberStatus));
 
         return memberRepository.save(findMember);
     }
@@ -45,8 +49,8 @@ public class MemberService {
     }
 
     // 멤버 목록 조회
-    public Member findMembers(int page, int size) {
-        return null;
+    public Page<Member> findMembers(int page, int size) {
+        return memberRepository.findAll(PageRequest.of(page, size, Sort.by("memberId").descending()));
     }
 
     // 멤버 삭제

--- a/src/main/java/com/codestates/notice_project/board/dto/BoardDto.java
+++ b/src/main/java/com/codestates/notice_project/board/dto/BoardDto.java
@@ -4,6 +4,7 @@ import com.codestates.notice_project.board.entity.Board;
 import lombok.*;
 
 import javax.validation.constraints.NotBlank;
+import java.util.List;
 
 public class BoardDto {
 

--- a/src/main/java/com/codestates/notice_project/board/entity/Board.java
+++ b/src/main/java/com/codestates/notice_project/board/entity/Board.java
@@ -1,11 +1,14 @@
 package com.codestates.notice_project.board.entity;
 
+import com.codestates.notice_project.Member.entity.MemberBoard;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import javax.persistence.*;
 import javax.validation.constraints.NotBlank;
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -26,6 +29,16 @@ public class Board {
     @Enumerated(value = EnumType.STRING)
     @Column(length = 50, nullable = false)
     private BoardStatus boardStatus = BoardStatus.BOARD_PUBLIC;
+
+    @OneToMany(mappedBy = "board")
+    private List<MemberBoard> memberBoards = new ArrayList<>();
+
+    public void addMemberBoard(MemberBoard memberBoard) {
+        this.memberBoards.add(memberBoard);
+        if (memberBoard.getBoard() != this) {
+            memberBoard.addBoard(this);
+        }
+    }
 
     public Board(long boardId, String writer, String comment) {
         this.boardId = boardId;


### PR DESCRIPTION
### MemberController
- DI의 final 키워드 누락 문제 수정
- getMembers 핸들러 메서드 페이지네이션 적용

### MemberDto
- 각 이너 클래스에 @Getter 애너테이션 추가
- Response 클래스에는 @AllArgsConstructor도 추가하였음

### Member
- @Entity 애너테이션 적용
- 엔티티 매핑
- MemberStatus enum 클래스 생성

### MemberBoard
- Member/entity 하위에 Board 엔티티와 Member 엔티티의 연결 테이블 생성

### MemberRepository
- findByEmail 생성

### MemberService
- updateMember 메서드에 MemberStatus 적용
- findmember 메서드에 페이지네이션 적용

### Board
- 엔티티 매핑

</br>

P.S. 다음부터는 자주 커밋하는 습관을 들이겠습니다 😅